### PR TITLE
Set socket options for Unix sockets

### DIFF
--- a/ext/libmemcached-0.32/libmemcached/memcached_connect.c
+++ b/ext/libmemcached-0.32/libmemcached/memcached_connect.c
@@ -176,6 +176,8 @@ static memcached_return unix_socket_connect(memcached_server_st *ptr)
 
     addrlen= (socklen_t) (strlen(servAddr.sun_path) + sizeof(servAddr.sun_family));
 
+    (void)set_socket_options(ptr);
+
 test_connect:
     if (connect(ptr->fd,
                 (struct sockaddr *)&servAddr,


### PR DESCRIPTION
 - Call `set_socket_options()` for `unix_socket_connect()`

The issue happens, because Unix sockets are not set up properly.

P.S. Don't review the style of Ruby code 😉 Those are existing tests for TCP which I modified for Unix sockets.

Specs:

```
Finished in 31.865044 seconds.
------
165 tests, 384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------
5.18 tests/s, 12.05 assertions/s
```


@vinted/backend @vinted/sre
